### PR TITLE
Remove deprecated option.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,10 +56,6 @@ disable = true
 # You won't be able to hash-query blockchain data.
 enable = false
 
-[dapps]
-# You won't be able to access any web Dapps.
-disable = true
-
 [mining]
 reseal_min_period = 0
 min_gas_price = 1


### PR DESCRIPTION
```
/home/parity/bin/parity --config /home/parity/config.toml
Loading config file from /home/parity/config.toml
Option '--no-dapps' has been removed and is no longer supported.
```