### PR TITLE
Adds faketime.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
+# use the base image to build with because we need to ensure that the library is built for the correct version
+FROM parity/parity@sha256:4a33438fe4cbd73a6ad37874becf3215c77ac3d7a567992ebd3ee4142fabdb5a as faketime
+USER root
+RUN apt-get --yes update && apt-get install --yes git make gcc ca-certificates
+RUN git clone https://github.com/wolfcw/libfaketime /libfaketime
+WORKDIR /libfaketime
+RUN make && make install
+
 # v2.7.2-stable
 FROM parity/parity@sha256:4a33438fe4cbd73a6ad37874becf3215c77ac3d7a567992ebd3ee4142fabdb5a
 
 WORKDIR /
+COPY --from=faketime /usr/local/lib/faketime/libfaketimeMT.so.1 /lib/faketime.so
 COPY dev-key.json /home/parity/keys/DevChain/dev-key.json
 COPY chain-spec.json /home/parity/chain-spec.json
 COPY config.toml /home/parity/config.toml
 RUN echo "" > /home/parity/password
+
+ENV LD_PRELOAD="/lib/faketime.so"
 
 ENTRYPOINT [ "/bin/parity", "--config", "/home/parity/config.toml" ]
 

--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,8 @@ cors = ["*"]
 apis = ["all"]
 # Allow connections only using specified addresses.
 hosts = ["all"]
+# Enable experimental JSON-RPC APIs
+experimental_rpcs = true
 
 [websockets]
 #  JSON-RPC will be listening for connections on IP 0.0.0.0.


### PR DESCRIPTION
By default, this will be a no-op.  However, you can set the environment variable `FAKETIME` to `@2020-01-02 03:04:05` in the container to make it so Nethermind thinks the time is always exactly that.  This will result in each block (i.e., each transaction) being 1 second ahead of the previous.

Next step is injecting a service that will let us change the time via an HTTP request.

Also enables experimental JSON-RPC methods, specifically `eth_getProof`.